### PR TITLE
Fixes typo: change 'Heml' to 'Helm'

### DIFF
--- a/content/setup-a-powerful-kubernetes-client/basics.md
+++ b/content/setup-a-powerful-kubernetes-client/basics.md
@@ -35,7 +35,7 @@ echo 'alias k=kubectl' >>~/.bashrc
 echo 'complete -F __start_kubectl k' >>~/.bashrc
 ```
 
-## Heml
+## Helm
 
 Easy peasy:
 


### PR DESCRIPTION
Thank you for putting your notes out there so that others may benefit! They have been helpful.

I stumbled across this typo and thought I'd submit a PR with a fix. 
